### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require appstract/laravel-blade-directives
 
 ### Provider
 
-Then add the ServiceProvider to your `config/app.php` file:
+In Laravel 5.5 the package will autoregister the service provider. In older Versions, you must add the ServiceProvider to your `config/app.php` file:
 
 ```php
 'providers' => [

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require appstract/laravel-blade-directives
 
 ### Provider
 
-In Laravel 5.5 the package will autoregister the service provider. In older Versions, you must add the ServiceProvider to your `config/app.php` file:
+In Laravel 5.5 the package will autoregister the Service Provider. In older versions, you must add the ServiceProvider to your `config/app.php` file:
 
 ```php
 'providers' => [


### PR DESCRIPTION
Added a note that, due to package discovery, adding the ServiceProvider manually is not necessary anymore when using Laravel 5.5