### PR TITLE
New @error directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,14 @@ Output data-attributes from an array.
 ```
 
 
-### @ifHasError
+### @hasError
 
 Quickly output for classical  ```$errors->has('input_name')``` to determine if any error messages exist for a given field.
 
 ```blade
-@ifHasError('input_name')
+@hasError('input_name')
     This input has an error
-@enderror
+@endhaserror
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,19 @@ Output data-attributes from an array.
 @data(['testing' => 123])
 ```
 
+
+### @error
+
+Quickly output for classical  ```$errors->has('input_name')``` to determine if any error messages exist for a given field.
+
+```blade
+@error('input_name')
+    This input has an error
+@enderror
+
+```
+
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -217,12 +217,12 @@ Output data-attributes from an array.
 ```
 
 
-### @error
+### @ifHasError
 
 Quickly output for classical  ```$errors->has('input_name')``` to determine if any error messages exist for a given field.
 
 ```blade
-@error('input_name')
+@ifHasError('input_name')
     This input has an error
 @enderror
 

--- a/src/directives.php
+++ b/src/directives.php
@@ -323,15 +323,15 @@ return [
 
     /*
     |---------------------------------------------------------------------
-    | @ifHasError
+    | @hasError
     |---------------------------------------------------------------------
     */
 
-    'ifHasError' => function ($expression) {
+    'hasError' => function ($expression) {
         return '<?php if (isset($errors) && $errors->has('.$expression.')): ?>';
     },
 
-    'enderror' => function () {
+    'endhaserror' => function () {
         return '<?php endif; ?>';
     },
 

--- a/src/directives.php
+++ b/src/directives.php
@@ -323,15 +323,15 @@ return [
 
     /*
     |---------------------------------------------------------------------
-    | @error
+    | @ifHasError
     |---------------------------------------------------------------------
     */
 
-    'error' => function ($expression) {
+    'ifHasError' => function ($expression) {
         return '<?php if (isset($errors) && $errors->has('.$expression.')): ?>';
     },
 
-    'enderror' => function ($expression) {
+    'enderror' => function () {
         return '<?php endif; ?>';
     },
 

--- a/src/directives.php
+++ b/src/directives.php
@@ -321,4 +321,18 @@ return [
         return '<i class="glyphicons glyphicons-'.DirectivesRepository::stripQuotes($expression->get(0)).' '.DirectivesRepository::stripQuotes($expression->get(1)).'"></i>';
     },
 
+    /*
+    |---------------------------------------------------------------------
+    | @error
+    |---------------------------------------------------------------------
+    */
+
+    'error' => function ($expression) {
+        return '<?php if (isset($errors) && $errors->has('.$expression.')): ?>';
+    },
+
+    'enderror' => function ($expression) {
+        return '<?php endif; ?>';
+    },
+
 ];

--- a/tests/Concerns/RendersBlade.php
+++ b/tests/Concerns/RendersBlade.php
@@ -42,6 +42,10 @@ trait RendersBlade
             return $value ? 'true' : 'false';
         }
         if (is_string($value)) {
+            if(strpos($value, 'MessageBag') !== false) //is a new MessageBag object
+            {
+                return $value;
+            }
             return '"'.$value.'"';
         }
 

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -213,7 +213,7 @@ class DirectivesTest extends TestCase
         //without errors var
         $this->assertBladeRenders(
             'Input: Has not errors',
-            'Input:@error($errors->has(\'input_name\')) This input has an error @enderror Has not errors'
+            'Input:@ifHasError($errors->has(\'input_name\')) This input has an error @enderror Has not errors'
         );
 
         $errors = "new \Illuminate\Support\MessageBag(['input_name' => 1])";
@@ -221,7 +221,7 @@ class DirectivesTest extends TestCase
         //with errors var
         $this->assertBladeRenders(
             'Input: This input has an error',
-            'Input:@error("input_name") This input has an error @enderror',
+            'Input:@ifHasError("input_name") This input has an error @enderror',
             [
                 'errors' => $errors
             ]

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -208,12 +208,12 @@ class DirectivesTest extends TestCase
         );
     }
 
-    public function test_error()
+    public function test_has_error()
     {
         //without errors var
         $this->assertBladeRenders(
             'Input: Has not errors',
-            'Input:@ifHasError($errors->has(\'input_name\')) This input has an error @enderror Has not errors'
+            'Input:@hasError($errors->has(\'input_name\')) This input has an error @endhaserror Has not errors'
         );
 
         $errors = "new \Illuminate\Support\MessageBag(['input_name' => 1])";
@@ -221,7 +221,7 @@ class DirectivesTest extends TestCase
         //with errors var
         $this->assertBladeRenders(
             'Input: This input has an error',
-            'Input:@ifHasError("input_name") This input has an error @enderror',
+            'Input:@hasError("input_name") This input has an error @endhaserror',
             [
                 'errors' => $errors
             ]

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -207,4 +207,24 @@ class DirectivesTest extends TestCase
             "@data(['foo' => 123, 'bar' => 'baz'])"
         );
     }
+
+    public function test_error()
+    {
+        //without errors var
+        $this->assertBladeRenders(
+            'Input: Has not errors',
+            'Input:@error($errors->has(\'input_name\')) This input has an error @enderror Has not errors'
+        );
+
+        $errors = "new \Illuminate\Support\MessageBag(['input_name' => 1])";
+
+        //with errors var
+        $this->assertBladeRenders(
+            'Input: This input has an error',
+            'Input:@error("input_name") This input has an error @enderror',
+            [
+                'errors' => $errors
+            ]
+        );
+    }
 }


### PR DESCRIPTION
In many of my projects I tend to use `@if ($ errors-> has ('input_name'))` to detect if an input has an error. For a more comfortable reading, I suggest you add this directive:

Replace this:

`
@if($errors->has('input_name'))
This input has an error
@endif
`

For:

`
@error('input_name')
    This input has an error
@enderror
`