### PR TITLE
Fix syntax error when inline CSS

### DIFF
--- a/src/directives.php
+++ b/src/directives.php
@@ -141,7 +141,7 @@ return [
     */
 
     'inline' => function ($expression) {
-        $include = "//  {$expression}\n".
+        $include = "/* {$expression} */\n".
                    "<?php include public_path({$expression}) ?>\n";
 
         if (ends_with($expression, ".html'")) {

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -75,15 +75,27 @@ class DirectivesTest extends TestCase
         );
     }
 
-    public function test_inline()
+    public function test_js_inline()
     {
         // see /tests/laravel/public/js/manifest-stub.js
         $this->assertBladeRenders(implode("\n", [
             '<script>',
-            "//  '/js/manifest-stub.js'",
+            "/* '/js/manifest-stub.js' */",
             '// manifest stub',
             '</script>',
         ]), "@inline('/js/manifest-stub.js')");
+    }
+
+    public function test_css_inline()
+    {
+        // see /tests/laravel/public/js/manifest-stub.js
+        $this->assertBladeRenders(implode("\n", [
+            '<style>',
+            "/* '/css/test.css' */",
+            '/* for Test */',
+            'body {}',
+            '</style>',
+        ]), "@inline('/css/test.css')");
     }
 
     public function test_pushonce()

--- a/tests/laravel/public/css/test.css
+++ b/tests/laravel/public/css/test.css
@@ -1,0 +1,2 @@
+/* for Test */
+body {}


### PR DESCRIPTION
To avoid syntax error in inlined CSS, use multi comment instead of single comment

I checked based on [CSSLint](https://github.com/CSSLint/csslint)