### PR TITLE
Enables deferring a script

### DIFF
--- a/src/directives.php
+++ b/src/directives.php
@@ -107,9 +107,10 @@ return [
     |---------------------------------------------------------------------
     */
 
-    'script' => function ($expression) {
+    'script' => function ($expression, $defer = null) {
         if (! empty($expression)) {
-            return '<script src="'.DirectivesRepository::stripQuotes($expression).'"></script>';
+            list($src, $defer) = explode(',',str_replace(['(',')',' '], '', $expression));
+            return '<script src="'.DirectivesRepository::stripQuotes($src).'"'.$defer.'></script>';
         }
 
         return '<script>';

--- a/src/directives.php
+++ b/src/directives.php
@@ -109,7 +109,7 @@ return [
 
     'script' => function ($expression, $defer = null) {
         if (! empty($expression)) {
-            [$src, $defer] = explode(',',str_replace(['(',')',' '], '', $expression));
+        [$src, $defer] = explode(',', str_replace(['(', ')', ' '], '', $expression));
             return '<script src="'.DirectivesRepository::stripQuotes($src).'"'.$defer.'></script>';
         }
 

--- a/src/directives.php
+++ b/src/directives.php
@@ -109,7 +109,7 @@ return [
 
     'script' => function ($expression, $defer = null) {
         if (! empty($expression)) {
-            list($src, $defer) = explode(',',str_replace(['(',')',' '], '', $expression));
+            [$src, $defer] = explode(',',str_replace(['(',')',' '], '', $expression));
             return '<script src="'.DirectivesRepository::stripQuotes($src).'"'.$defer.'></script>';
         }
 


### PR DESCRIPTION
I wanted to use @script with an additional `defer` parameter.

This PR enables using @script('script.js', defer).

To achieve this, the directive extracts `$expression` into  `$script` and `$defer` variables which are returned in the right place to assemble the resulting `<script ....></script>` tag.